### PR TITLE
Let message_test run from commandline

### DIFF
--- a/openomni/message_test.py
+++ b/openomni/message_test.py
@@ -43,3 +43,7 @@ class MessageTestCase(unittest.TestCase):
         insulin_cmd = msg.commands()[0]
 
         self.assertTrue(isinstance(insulin_cmd, InsulinScheduleCommand))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds boilerplate to run unittest main when directly invoked from the commandline